### PR TITLE
MAF 3.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "packages/validations"
       ],
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "lerna": "^7.1.4",
         "multiple-cucumber-html-reporter": "^3.4.0",
         "nyc": "^15.1.0"
@@ -1641,26 +1641,26 @@
       }
     },
     "node_modules/@cucumber/ci-environment": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-9.2.0.tgz",
-      "integrity": "sha512-jLzRtVwdtNt+uAmTwvXwW9iGYLEOJFpDSmnx/dgoMGKXUWRx1UHT86Q696CLdgXO8kyTwsgJY0c6n5SW9VitAA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-10.0.0.tgz",
+      "integrity": "sha512-lRkiehckosIOdc7p1L44nZsttO5dVHFjpwKKWZ07x8SeoAdV/sPuGe1PISe0AmAowFGza62nMOgG4KaroGzwFQ==",
       "dev": true
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-9.6.0.tgz",
-      "integrity": "sha512-bCw2uJdGHHLg4B3RoZpLzx0RXyXURmPe+swtdK1cGoA8rs+vv+/6osifcNwvFM2sv0nQ91+gDACSrXK7AHCylg==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-10.1.0.tgz",
+      "integrity": "sha512-9itQdAccTqJAe9VfdmovinOlUPLroC2KbB+CeQty8BKXpLB6hKO32k9S9FhnuXinFqh+E5znUrPtbUxS948bwQ==",
       "dev": true,
       "dependencies": {
-        "@cucumber/ci-environment": "9.2.0",
-        "@cucumber/cucumber-expressions": "16.1.2",
-        "@cucumber/gherkin": "26.2.0",
+        "@cucumber/ci-environment": "10.0.0",
+        "@cucumber/cucumber-expressions": "17.0.1",
+        "@cucumber/gherkin": "27.0.0",
         "@cucumber/gherkin-streams": "5.0.1",
-        "@cucumber/gherkin-utils": "8.0.2",
-        "@cucumber/html-formatter": "20.4.0",
+        "@cucumber/gherkin-utils": "8.0.5",
+        "@cucumber/html-formatter": "21.2.0",
         "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "22.0.0",
-        "@cucumber/tag-expressions": "5.0.1",
+        "@cucumber/messages": "24.0.1",
+        "@cucumber/tag-expressions": "6.0.0",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
@@ -1669,7 +1669,7 @@
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
         "figures": "^3.2.0",
-        "glob": "^7.1.6",
+        "glob": "^10.3.10",
         "has-ansi": "^4.0.1",
         "indent-string": "^4.0.0",
         "is-installed-globally": "^0.4.0",
@@ -1681,14 +1681,15 @@
         "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
+        "read-pkg-up": "^7.0.1",
         "resolve-pkg": "^2.0.0",
         "semver": "7.5.3",
-        "string-argv": "^0.3.1",
+        "string-argv": "0.3.1",
         "strip-ansi": "6.0.1",
         "supports-color": "^8.1.1",
         "tmp": "^0.2.1",
+        "type-fest": "^4.8.3",
         "util-arity": "^1.1.0",
-        "verror": "^1.10.0",
         "xmlbuilder": "^15.1.1",
         "yaml": "^2.2.2",
         "yup": "1.2.0"
@@ -1697,22 +1698,283 @@
         "cucumber-js": "bin/cucumber.js"
       },
       "engines": {
-        "node": "14 || 16 || >=18"
+        "node": "18 || >=20"
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "16.1.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-16.1.2.tgz",
-      "integrity": "sha512-CfHEbxJ5FqBwF6mJyLLz4B353gyHkoi6cCL4J0lfDZ+GorpcWw4n2OUAdxJmP7ZlREANWoTFlp4FhmkLKrCfUA==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-17.0.1.tgz",
+      "integrity": "sha512-reR7/sNRmDWgdz8BtFuHEwpksPnAkHty7gxUC2n0iaUPmckv9G5I5i+Vonc6xwUHDb/hmHPz/DyUL+Iv4Ao96w==",
       "dev": true,
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
     },
+    "node_modules/@cucumber/cucumber/node_modules/@cucumber/messages": {
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-24.0.1.tgz",
+      "integrity": "sha512-dKfNkvgc6stSQIyeHk7p/221iqEZe1BP+e/Js8XKtSmc0sS8khKMvbSBwYVeonn/67/vYKiAyo6Eo0SzXd5Plw==",
+      "dev": true,
+      "dependencies": {
+        "@types/uuid": "9.0.7",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.1",
+        "uuid": "9.0.1"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/@types/uuid": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.7.tgz",
+      "integrity": "sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==",
+      "dev": true
+    },
+    "node_modules/@cucumber/cucumber/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/@cucumber/cucumber/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/reflect-metadata": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "dev": true
+    },
+    "node_modules/@cucumber/cucumber/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/type-fest": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
+      "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@cucumber/cucumber/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@cucumber/gherkin": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.2.0.tgz",
-      "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-27.0.0.tgz",
+      "integrity": "sha512-j5rCsjqzRiC3iVTier3sa0kzyNbkcAmF7xr7jKnyO7qDeK3Z8Ye1P3KSVpeQRMY+KCDJ3WbTDdyxH0FwfA/fIw==",
       "dev": true,
       "dependencies": {
         "@cucumber/messages": ">=19.1.4 <=22"
@@ -1746,15 +2008,15 @@
       }
     },
     "node_modules/@cucumber/gherkin-utils": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-8.0.2.tgz",
-      "integrity": "sha512-aQlziN3r3cTwprEDbLEcFoMRQajb9DTOu2OZZp5xkuNz6bjSTowSY90lHUD2pWT7jhEEckZRIREnk7MAwC2d1A==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-8.0.5.tgz",
+      "integrity": "sha512-kxM1OCDjYddF26VKc892PF0GokW4wUIl1PUz3TIXsPZgS39ExM1pF8oww8mlGFD2B0+4op/cSE3SSIME5H3aNw==",
       "dev": true,
       "dependencies": {
-        "@cucumber/gherkin": "^25.0.0",
-        "@cucumber/messages": "^19.1.4",
-        "@teppeis/multimaps": "2.0.0",
-        "commander": "9.4.1",
+        "@cucumber/gherkin": "^26.0.0",
+        "@cucumber/messages": "^22.0.0",
+        "@teppeis/multimaps": "3.0.0",
+        "commander": "10.0.1",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -1762,54 +2024,18 @@
       }
     },
     "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-25.0.2.tgz",
-      "integrity": "sha512-EdsrR33Y5GjuOoe2Kq5Y9DYwgNRtUD32H4y2hCrT6+AWo7ibUQu7H+oiWTgfVhwbkHsZmksxHSxXz/AwqqyCRQ==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-26.2.0.tgz",
+      "integrity": "sha512-iRSiK8YAIHAmLrn/mUfpAx7OXZ7LyNlh1zT89RoziSVCbqSVDxJS6ckEzW8loxs+EEXl0dKPQOXiDmbHV+C/fA==",
       "dev": true,
       "dependencies": {
-        "@cucumber/messages": "^19.1.4"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/messages": {
-      "version": "19.1.4",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-19.1.4.tgz",
-      "integrity": "sha512-Pksl0pnDz2l1+L5Ug85NlG6LWrrklN9qkMxN5Mv+1XZ3T6u580dnE6mVaxjJRdcOq4tR17Pc0RqIDZMyVY1FlA==",
-      "dev": true,
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "class-transformer": "0.5.1",
-        "reflect-metadata": "0.1.13",
-        "uuid": "9.0.0"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
-      "dev": true
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
-      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
-    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "@cucumber/messages": ">=19.1.4 <=22"
       }
     },
     "node_modules/@cucumber/html-formatter": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-20.4.0.tgz",
-      "integrity": "sha512-TnLSXC5eJd8AXHENo69f5z+SixEVtQIf7Q2dZuTpT/Y8AOkilGpGl1MQR1Vp59JIw+fF3EQSUKdf+DAThCxUNg==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.2.0.tgz",
+      "integrity": "sha512-4OcSa12Y0v5e4ySDl67+QFTxCG/Y9fxGSkFqvm98ggpTvS7b75whwzupu+lM2lMBw+h3H6P8ZURQr0xQIAwE2A==",
       "dev": true,
       "peerDependencies": {
         "@cucumber/messages": ">=18"
@@ -1844,9 +2070,9 @@
       }
     },
     "node_modules/@cucumber/tag-expressions": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-5.0.1.tgz",
-      "integrity": "sha512-N43uWud8ZXuVjza423T9ZCIJsaZhFekmakt7S9bvogTxqdVGbRobjR663s0+uW0Rz9e+Pa8I6jUuWtoBLQD2Mw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.0.0.tgz",
+      "integrity": "sha512-JbNb/254Wn6b8cfrIJoqR0NekHXvoB/eMvSY4RK11H8k+YZfm7mZesu/3yVX67nkW+Y+PGjZFcgTMcfjwFRsRw==",
       "dev": true
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -4048,12 +4274,12 @@
       }
     },
     "node_modules/@teppeis/multimaps": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-2.0.0.tgz",
-      "integrity": "sha512-TL1adzq1HdxUf9WYduLcQ/DNGYiz71U31QRgbnr0Ef1cPyOUOsBojxHVWpFeOSUucB6Lrs0LxFRA14ntgtkc9w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+      "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
       "dev": true,
       "engines": {
-        "node": ">=10.17"
+        "node": ">=14"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -4557,15 +4783,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/assertion-error": {
@@ -6640,15 +6857,6 @@
       "engines": {
         "node": ">=0.6.0"
       }
-    },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ]
     },
     "node_modules/eyes": {
       "version": "0.1.8",
@@ -13695,9 +13903,9 @@
       }
     },
     "node_modules/string-argv": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+      "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
       "dev": true,
       "engines": {
         "node": ">=0.6.19"
@@ -14781,20 +14989,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -15222,7 +15416,7 @@
         "node-fetch": "^2.0.0"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "^2.0.1",
         "@ln-maf/validations": "file:../validations",
         "eslint": "^8.18.0",
@@ -15256,7 +15450,7 @@
         "luxon": "^2.4.0"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "*",
         "@ln-maf/validations": "^2.0.3",
         "eslint": "^8.51.0",
@@ -15288,7 +15482,7 @@
         "multiReport": "multiReport.js"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "eslint": "^8.18.0",
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.26.0",
@@ -15311,7 +15505,7 @@
         "prompt": "^1.2.2"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "^2.0.1",
         "@ln-maf/validations": "^2.0.1",
         "eslint": "^8.18.0",
@@ -15341,7 +15535,7 @@
         "mysql-configure": "config.js"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "^2.0.1",
         "@ln-maf/validations": "^2.0.3",
         "eslint": "^8.18.0",
@@ -15370,7 +15564,7 @@
         "postgresql-configure": "config.js"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "^2.0.0",
         "@ln-maf/validations": "^2.0.3",
         "eslint": "^8.0.0",
@@ -15404,7 +15598,7 @@
         "preprocessor": "exec.js"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "^2.0.1",
         "@ln-maf/validations": "^2.0.1",
         "eslint": "^8.18.0",
@@ -15443,7 +15637,7 @@
         "xpath": "0.0.32"
       },
       "devDependencies": {
-        "@cucumber/cucumber": "^9.0.0",
+        "@cucumber/cucumber": "^10.0.0",
         "@ln-maf/core": "^2.0.1",
         "eslint": "^8.18.0",
         "eslint-config-standard": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "lerna": "^7.1.4",
     "multiple-cucumber-html-reporter": "^3.4.0",
     "nyc": "^15.1.0"

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,7 @@
     "chai": "^4.3.4"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "^2.0.1",
     "@ln-maf/validations": "file:../validations",
     "eslint": "^8.18.0",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -28,7 +28,7 @@
     "@ln-maf/core": "*"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "*",
     "@ln-maf/validations": "^2.0.3",
     "eslint": "^8.51.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/hpcc-systems/MAF#readme",
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "eslint": "^8.18.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.26.0",

--- a/packages/defaultSQL/package.json
+++ b/packages/defaultSQL/package.json
@@ -22,7 +22,7 @@
     "keytar": "7.*"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "^2.0.1",
     "@ln-maf/validations": "^2.0.1",
     "eslint": "^8.18.0",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -24,7 +24,7 @@
     "@ln-maf/core": "*"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "^2.0.1",
     "@ln-maf/validations": "^2.0.3",
     "eslint": "^8.18.0",

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -24,7 +24,7 @@
     "@ln-maf/core": "*"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "^2.0.0",
     "@ln-maf/validations": "^2.0.3",
     "eslint": "^8.0.0",

--- a/packages/preprocessor/package.json
+++ b/packages/preprocessor/package.json
@@ -30,7 +30,7 @@
     "@ln-maf/core": "*"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "^2.0.1",
     "@ln-maf/validations": "^2.0.1",
     "eslint": "^8.18.0",

--- a/packages/validations/package.json
+++ b/packages/validations/package.json
@@ -26,7 +26,7 @@
     "@ln-maf/core": "*"
   },
   "devDependencies": {
-    "@cucumber/cucumber": "^9.0.0",
+    "@cucumber/cucumber": "^10.0.0",
     "@ln-maf/core": "^2.0.1",
     "eslint": "^8.18.0",
     "eslint-config-standard": "^17.0.0",


### PR DESCRIPTION
[multiple-cucumber-html-reporter](https://www.npmjs.com/package/multiple-cucumber-html-reporter) needs to fix base64 encoding for cucumber 10.0.0. Issue is being tracked [here](https://github.com/WasiqB/multiple-cucumber-html-reporter/issues/298) and [here](https://github.com/WasiqB/multiple-cucumber-html-reporter/pull/297)