### PR TITLE
Patching security issues and A small AWS bug

### DIFF
--- a/.github/workflows/package-api.yml
+++ b/.github/workflows/package-api.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       
-      - run: npm ci
+      - run: npm install
       
       - run: npm run test -w packages/api
         env: 

--- a/.github/workflows/package-aws.yml
+++ b/.github/workflows/package-aws.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3.1.2
     - run: mkdir ~/.aws/
-    - run: npm ci
+    - run: npm install
     - name: Terraform - apply to localstack
       run: |
         cd packages/aws/terraform

--- a/.github/workflows/package-default-sql.yml
+++ b/.github/workflows/package-default-sql.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       
-      - run: npm ci
+      - run: npm install
       
       - run: npm test -w packages/defaultSQL
         env: 

--- a/.github/workflows/package-mysql.yml
+++ b/.github/workflows/package-mysql.yml
@@ -49,7 +49,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       
       - name: Wait for MySQL to be ready
         run: |

--- a/.github/workflows/package-postgresql.yml
+++ b/.github/workflows/package-postgresql.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       
       - name: Wait for PostgreSQL to be ready
         run: |

--- a/.github/workflows/package-preprocessor.yml
+++ b/.github/workflows/package-preprocessor.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       
-      - run: npm ci
+      - run: npm install
       
       - run: npm test -w packages/preprocessor
         env: 

--- a/.github/workflows/package-sftp.yml
+++ b/.github/workflows/package-sftp.yml
@@ -46,7 +46,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       
       - name: Test SFTP Package
         run: npm run test:run -w packages/sftp

--- a/.github/workflows/package-validations.yml
+++ b/.github/workflows/package-validations.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       
-      - run: npm ci
+      - run: npm install
       
       - run: npm run test:coverage -w packages/validations
         env: 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint": "^9.31.0",
     "globals": "^16.3.0",
     "lerna": "^9.0.0",
-    "multiple-cucumber-html-reporter": "3.7.0",
-    "nyc": "^17.1.0"
+    "multiple-cucumber-html-reporter": "3.10.0",
+    "nyc": "^18.0.0"
   }
 }

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.2.3](https://github.com/hpcc-systems/MAF/compare/@ln-maf/api@4.2.1...@ln-maf/api@4.2.3) (2026-06-04)
+
+
+### Features
+
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.2.2](https://github.com/hpcc-systems/MAF/compare/@ln-maf/api@4.2.1...@ln-maf/api@4.2.2) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/api

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,7 +29,7 @@
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
     "concurrently": "^8.0.0",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.0.1"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "MAF module providing API steps",
   "main": "index.js",
   "scripts": {
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "concurrently": "^8.0.0",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",

--- a/packages/aws/CHANGELOG.md
+++ b/packages/aws/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.9](https://github.com/hpcc-systems/MAF/compare/@ln-maf/aws@4.1.7...@ln-maf/aws@4.1.9) (2026-06-04)
+
+
+### Bug Fixes
+
+* add pragma allowlist for secret access keys in AWS configurations ([48e8046](https://github.com/hpcc-systems/MAF/commit/48e80467aead472300038083272d99c3478de1b6))
+
+
+### Features
+
+* enhance base64 handling and add binary attribute decoding ([24a4b75](https://github.com/hpcc-systems/MAF/commit/24a4b75f8727cc09848a7e4d6e88b7c225cc96d3))
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.8](https://github.com/hpcc-systems/MAF/compare/@ln-maf/aws@4.1.7...@ln-maf/aws@4.1.8) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/aws

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.8",
+  "version": "4.1.10",
   "description": "AWS steps for MAF. This contains S3, DynamoDB, SQS, ECS, Cloudwatch, and Lambda stepDefinitions",
   "main": "index.js",
   "scripts": {
@@ -41,8 +41,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.2.0"

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -43,7 +43,7 @@
     "@cucumber/cucumber": "^12.0.0",
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.2.0"
   },

--- a/packages/aws/stepDefinitions/cloudwatch-logs.js
+++ b/packages/aws/stepDefinitions/cloudwatch-logs.js
@@ -12,7 +12,7 @@ if (process.env.AWSENV && process.env.AWSENV.toUpperCase() === 'LOCALSTACK') {
     cloudwatchLogsClientConfig.region = 'us-east-1'
     cloudwatchLogsClientConfig.credentials = {
         accessKeyId: 'test',
-        secretAccessKey: 'test'
+        secretAccessKey: 'test' // pragma: allowlist secret
     }
 }
 const cloudwatchLogsClient = new CloudWatchLogsClient(cloudwatchLogsClientConfig)
@@ -29,7 +29,7 @@ MAFWhen('parameter {string} value is retrieved from the parameter store', async 
         ssmClientConfig.region = 'us-east-1'
         ssmClientConfig.credentials = {
             accessKeyId: 'test',
-            secretAccessKey: 'test'
+            secretAccessKey: 'test' // pragma: allowlist secret
         }
     }
     const ssmClient = new SSMClient(ssmClientConfig)

--- a/packages/aws/stepDefinitions/dynamodb.js
+++ b/packages/aws/stepDefinitions/dynamodb.js
@@ -12,7 +12,8 @@ const {
 // Constants
 const TIMEOUT_MINUTES = 15
 const LOCALSTACK_PORT = 4566
-const BASE64_REGEX = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/
+// Requires padding (=) to avoid false positives on plain alphanumeric strings
+const BASE64_REGEX = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)$/
 
 // DynamoDB attribute types
 const DYNAMO_TYPES = {
@@ -42,7 +43,7 @@ if (process.env.AWSENV && process.env.AWSENV.toUpperCase() === 'LOCALSTACK') {
     DynamoDBClientConfig.region = 'us-east-1'
     DynamoDBClientConfig.credentials = {
         accessKeyId: 'test',
-        secretAccessKey: 'test'
+        secretAccessKey: 'test' // pragma: allowlist secret
     }
 }
 
@@ -185,7 +186,7 @@ function convertValueToDynamoType(value) {
 
     // Handle string values
     if (typeof value === 'string') {
-        // Check if it's base64 encoded
+        // Check if it's base64 encoded (requires padding to avoid false positives)
         if (BASE64_REGEX.test(value)) {
             return { [DYNAMO_TYPES.BINARY]: value }
         }
@@ -199,6 +200,28 @@ function convertValueToDynamoType(value) {
 
     // Default to string for other types
     return { [DYNAMO_TYPES.STRING]: String(value) }
+}
+
+/**
+ * Recursively converts DynamoDB Binary (B) attribute values from base64 strings
+ * to Buffers, as required by AWS SDK v3.
+ * @param {Object} item DynamoDB item with attribute type objects
+ * @returns {Object} Item with B values decoded to Buffer
+ */
+function decodeBinaryAttributes(item) {
+    if (!item || typeof item !== 'object') return item
+    if (Array.isArray(item)) return item.map(decodeBinaryAttributes)
+    const result = {}
+    for (const [key, value] of Object.entries(item)) {
+        if (value && typeof value === 'object' && typeof value[DYNAMO_TYPES.BINARY] === 'string') {
+            result[key] = { [DYNAMO_TYPES.BINARY]: Buffer.from(value[DYNAMO_TYPES.BINARY], 'base64') }
+        } else if (value && typeof value === 'object') {
+            result[key] = decodeBinaryAttributes(value)
+        } else {
+            result[key] = value
+        }
+    }
+    return result
 }
 
 MAFWhen('{jsonObject} is converted to dynamo', function (payload) {
@@ -477,7 +500,7 @@ async function putItem(activeArgs = {}, additionalArgs = {}) {
     }
 
     this.attach(JSON.stringify(queryParameters))
-    return await dbClient.send(new PutItemCommand(queryParameters))
+    return await dbClient.send(new PutItemCommand(decodeBinaryAttributes(queryParameters)))
 }
 
 /**

--- a/packages/aws/stepDefinitions/ecs.js
+++ b/packages/aws/stepDefinitions/ecs.js
@@ -10,7 +10,7 @@ if (process.env.AWSENV && process.env.AWSENV.toUpperCase() === 'LOCALSTACK') {
     ecsClientConfig.region = 'us-east-1'
     ecsClientConfig.credentials = {
         accessKeyId: 'test',
-        secretAccessKey: 'test'
+        secretAccessKey: 'test' // pragma: allowlist secret
     }
 }
 const ecsClient = new ECSClient(ecsClientConfig)

--- a/packages/aws/stepDefinitions/lambda.js
+++ b/packages/aws/stepDefinitions/lambda.js
@@ -10,7 +10,7 @@ if (process.env.AWSENV && process.env.AWSENV.toUpperCase() === 'LOCALSTACK') {
     lambdaClientConfig.region = 'us-east-1'
     lambdaClientConfig.credentials = {
         accessKeyId: 'test',
-        secretAccessKey: 'test'
+        secretAccessKey: 'test' // pragma: allowlist secret
     }
 }
 const lambdaClient = new LambdaClient(lambdaClientConfig)

--- a/packages/aws/stepDefinitions/s3.js
+++ b/packages/aws/stepDefinitions/s3.js
@@ -19,7 +19,7 @@ if (process.env.AWSENV && process.env.AWSENV.toUpperCase() === 'LOCALSTACK') {
     S3ClientConfig.region = 'us-east-1'
     S3ClientConfig.credentials = {
         accessKeyId: 'test',
-        secretAccessKey: 'test'
+        secretAccessKey: 'test' // pragma: allowlist secret
     }
 }
 const s3Client = new S3Client(S3ClientConfig)

--- a/packages/aws/stepDefinitions/sqs.js
+++ b/packages/aws/stepDefinitions/sqs.js
@@ -23,7 +23,7 @@ if (process.env.AWSENV && process.env.AWSENV.toUpperCase() === 'LOCALSTACK') {
     sqsClientConfig.region = 'us-east-1'
     sqsClientConfig.credentials = {
         accessKeyId: 'test',
-        secretAccessKey: 'test'
+        secretAccessKey: 'test' // pragma: allowlist secret
     }
 }
 

--- a/packages/aws/terraform/main.tf
+++ b/packages/aws/terraform/main.tf
@@ -22,7 +22,7 @@ variable "localstack_host" {
 provider "aws" {
   region                      = "us-east-1"
   access_key                  = "test"
-  secret_key                  = "test"
+  secret_key                  = "test" # pragma: allowlist secret
   skip_credentials_validation = true
   skip_requesting_account_id  = true
   skip_metadata_api_check     = true

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.6](https://github.com/hpcc-systems/MAF/compare/@ln-maf/core@4.1.5...@ln-maf/core@4.1.6) (2026-06-04)
+
+**Note:** Version bump only for package @ln-maf/core
+
+
+
+
+
 ## [4.1.5](https://github.com/hpcc-systems/MAF/compare/@ln-maf/core@4.1.4...@ln-maf/core@4.1.5) (2025-10-28)
 
 **Note:** Version bump only for package @ln-maf/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "The core for the MAF framework. Contains helpers to make it easier to use.",
   "main": "index.js",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/hpcc-systems/MAF/issues"
   },
   "dependencies": {
-    "multiple-cucumber-html-reporter": "3.9.3"
+    "multiple-cucumber-html-reporter": "3.10.0"
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",

--- a/packages/defaultSQL/CHANGELOG.md
+++ b/packages/defaultSQL/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.9](https://github.com/hpcc-systems/MAF/compare/@ln-maf/default-sql@4.1.7...@ln-maf/default-sql@4.1.9) (2026-06-04)
+
+
+### Features
+
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.8](https://github.com/hpcc-systems/MAF/compare/@ln-maf/default-sql@4.1.7...@ln-maf/default-sql@4.1.8) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/default-sql

--- a/packages/defaultSQL/package.json
+++ b/packages/defaultSQL/package.json
@@ -30,7 +30,7 @@
     "@cucumber/cucumber": "^12.0.0",
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "^3.10.0",
     "nyc": "^17.0.0"
   },
   "repository": {

--- a/packages/defaultSQL/package.json
+++ b/packages/defaultSQL/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Default Sql setup on Node with cucumber",
   "main": "index.js",
   "scripts": {
@@ -28,8 +28,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "multiple-cucumber-html-reporter": "^3.10.0",
     "nyc": "^17.0.0"
   },

--- a/packages/mysql/CHANGELOG.md
+++ b/packages/mysql/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.9](https://github.com/hpcc-systems/MAF/compare/@ln-maf/mysql@4.1.7...@ln-maf/mysql@4.1.9) (2026-06-04)
+
+
+### Features
+
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.8](https://github.com/hpcc-systems/MAF/compare/@ln-maf/mysql@4.1.7...@ln-maf/mysql@4.1.8) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/mysql

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "Setup for sql on Node",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@ln-maf/default-sql": "^4.1.8",
+    "@ln-maf/default-sql": "^4.1.9",
     "keytar": "^7.9.0",
     "mysql2": "^3.9.7"
   },
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "concurrently": "^8.2.2",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -37,7 +37,7 @@
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
     "concurrently": "^8.2.2",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.2.0"
   },

--- a/packages/postgresql/CHANGELOG.md
+++ b/packages/postgresql/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.9](https://github.com/hpcc-systems/MAF/compare/@ln-maf/postgresql@4.1.7...@ln-maf/postgresql@4.1.9) (2026-06-04)
+
+
+### Features
+
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.8](https://github.com/hpcc-systems/MAF/compare/@ln-maf/postgresql@4.1.7...@ln-maf/postgresql@4.1.8) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/postgresql

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "PostgreSQL support / step definitions for MAF",
   "main": "index.js",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@ln-maf/default-sql": "^4.1.8",
+    "@ln-maf/default-sql": "^4.1.9",
     "keytar": "^7.9.0",
     "pg": "^8.0.0"
   },
@@ -34,8 +34,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "concurrently": "^8.2.2",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",

--- a/packages/postgresql/package.json
+++ b/packages/postgresql/package.json
@@ -37,7 +37,7 @@
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
     "concurrently": "^8.2.2",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.2.0"
   },

--- a/packages/preprocessor/CHANGELOG.md
+++ b/packages/preprocessor/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.9](https://github.com/hpcc-systems/MAF/compare/@ln-maf/preprocessor@4.1.7...@ln-maf/preprocessor@4.1.9) (2026-06-04)
+
+
+### Features
+
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.8](https://github.com/hpcc-systems/MAF/compare/@ln-maf/preprocessor@4.1.7...@ln-maf/preprocessor@4.1.8) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/preprocessor

--- a/packages/preprocessor/package.json
+++ b/packages/preprocessor/package.json
@@ -22,7 +22,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/cucumber-expressions": "^12.1.3",
-    "@cucumber/messages": "^22.0.0",
+    "@cucumber/messages": "^32.3.1",
     "app-root-path": "^3.0.0",
     "command-line-args": "^5.2.1",
     "glob": "^11.0.0",
@@ -37,7 +37,7 @@
     "@cucumber/cucumber": "^12.0.0",
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0"
   },
   "repository": {

--- a/packages/preprocessor/package.json
+++ b/packages/preprocessor/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.8",
+  "version": "4.1.9",
   "description": "This project will preprocess feature files to allow more input variables to be supplied.  This can be supplied through javascript, a csv/psv/json array file or a mixture of these.  This will hopefully allow it to be easier to maintain larger test sets.",
   "main": "index.js",
   "bin": {
@@ -35,8 +35,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0"
   },

--- a/packages/sftp/CHANGELOG.md
+++ b/packages/sftp/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.7](https://github.com/hpcc-systems/MAF/compare/@ln-maf/sftp@4.1.5...@ln-maf/sftp@4.1.7) (2026-06-04)
+
+
+### Features
+
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.6](https://github.com/hpcc-systems/MAF/compare/@ln-maf/sftp@4.1.5...@ln-maf/sftp@4.1.6) (2026-02-03)
 
 **Note:** Version bump only for package @ln-maf/sftp

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -31,7 +31,7 @@
     "@cucumber/cucumber": "^12.0.0",
     "@ln-maf/core": "^4.1.5",
     "@ln-maf/validations": "^4.1.6",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.2.0"
   },

--- a/packages/sftp/package.json
+++ b/packages/sftp/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "SFTP step definitions for MAF",
   "main": "index.js",
   "scripts": {
@@ -29,8 +29,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
-    "@ln-maf/validations": "^4.1.6",
+    "@ln-maf/core": "^4.1.6",
+    "@ln-maf/validations": "^4.1.7",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0",
     "wait-on": "^7.2.0"

--- a/packages/validations/CHANGELOG.md
+++ b/packages/validations/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.1.7](https://github.com/hpcc-systems/MAF/compare/@ln-maf/validations@4.1.5...@ln-maf/validations@4.1.7) (2026-06-04)
+
+
+### Features
+
+* add scenario for appending JSON items as line-delimited to file ([eb5bb44](https://github.com/hpcc-systems/MAF/commit/eb5bb44c3333b427c718f767925cae7bc26ae4d1))
+* **validations:** update JSON path handling to use jsonpath-plus ([eabf950](https://github.com/hpcc-systems/MAF/commit/eabf950c8abc93e13b2d398ad5e7c82c4c256ece))
+
+
+
+
+
 ## [4.1.6](https://github.com/hpcc-systems/MAF/compare/@ln-maf/validations@4.1.5...@ln-maf/validations@4.1.6) (2026-02-03)
 
 

--- a/packages/validations/package.json
+++ b/packages/validations/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "4.1.6",
+  "version": "4.1.7",
   "description": "Validation step definitions for MAF",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
-    "@ln-maf/core": "^4.1.5",
+    "@ln-maf/core": "^4.1.6",
     "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0"
   },

--- a/packages/validations/package.json
+++ b/packages/validations/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@cucumber/cucumber": "^12.0.0",
     "@ln-maf/core": "^4.1.5",
-    "multiple-cucumber-html-reporter": "3.7.0",
+    "multiple-cucumber-html-reporter": "3.10.0",
     "nyc": "^17.0.0"
   },
   "repository": {


### PR DESCRIPTION
- **chore(deps): update multiple-cucumber-html-reporter to version 3.10.0 and nyc to version 18.0.0**
- **feat: enhance base64 handling and add binary attribute decoding**
- **fix: add pragma allowlist for secret access keys in AWS configurations**
